### PR TITLE
Added EnemyUnitMemoryService

### DIFF
--- a/Sharky/DefaultBot/DefaultSharkyBot.cs
+++ b/Sharky/DefaultBot/DefaultSharkyBot.cs
@@ -12,6 +12,7 @@
         public UnitDataManager UnitDataManager { get; set; }
         public MapManager MapManager { get; set; }
         public UnitManager UnitManager { get; set; }
+        public EnemyUnitMemoryService enemyUnitMemoryService { get; set; }
         public EnemyRaceManager EnemyRaceManager { get; set; }
         public BaseManager BaseManager { get; set; }
         public TargetingManager TargetingManager { get; set; }
@@ -215,7 +216,8 @@
             DamageService = new DamageService();
             BuildingService = new BuildingService(MapData, ActiveUnitData, TargetingData, BaseData, SharkyUnitData);
 
-            UnitManager = new UnitManager(ActiveUnitData, SharkyUnitData, BaseData, EnemyData, SharkyOptions, TargetPriorityService, CollisionCalculator, MapDataService, DebugService, DamageService, UnitDataService);
+            enemyUnitMemoryService = new EnemyUnitMemoryService(ActiveUnitData);
+            UnitManager = new UnitManager(ActiveUnitData, SharkyUnitData, BaseData, EnemyData, SharkyOptions, TargetPriorityService, CollisionCalculator, MapDataService, DebugService, DamageService, UnitDataService,enemyUnitMemoryService);
             Managers.Add(UnitManager);
 
             HttpClient = new HttpClient();

--- a/Sharky/EnemyUnitMemoryService.cs
+++ b/Sharky/EnemyUnitMemoryService.cs
@@ -1,0 +1,66 @@
+﻿using SC2APIProtocol;
+
+namespace Sharky
+{
+
+    /// <summary>
+    /// A service to count all units the enemy could have
+    /// </summary>
+    public class EnemyUnitMemoryService
+    {
+        
+        private ActiveUnitData ActiveUnitData;
+        public Dictionary<UnitTypes, int> CurrentTotalUnits;
+        /// <summary>
+        /// Key is the UnitType and value is a dictionary with the frame the corresponding count of total units to that time is last updated 
+        /// </summary>
+        public Dictionary<UnitTypes, Dictionary<uint, int>> LastTotalUnits;
+
+        public EnemyUnitMemoryService(ActiveUnitData ActiveUnitData)
+        {
+            
+            this.ActiveUnitData = ActiveUnitData;
+
+
+            CurrentTotalUnits = new Dictionary<UnitTypes, int>();
+            LastTotalUnits = new Dictionary<UnitTypes, Dictionary<uint, int>>();
+        }
+
+        public void UpdateEnemyCount(UnitTypes type,int newCount, uint frame)
+        {
+            if (!LastTotalUnits.ContainsKey(type))
+            {
+                LastTotalUnits[type] = new Dictionary<uint, int>();
+            }
+
+            LastTotalUnits[type][frame] = newCount;
+            CurrentTotalUnits[type] = newCount;
+        }
+
+        public void ProcessActiveUnitData(Dictionary<ulong,UnitCalculation> currentEnemyCount, uint frame)
+        {
+            Dictionary<UnitTypes, int> typeCounts = new Dictionary<UnitTypes, int>();
+
+            foreach (var enemy in currentEnemyCount.Values)
+            {
+                if (typeCounts.ContainsKey((UnitTypes)enemy.Unit.UnitType))
+                {
+                    typeCounts[(UnitTypes)enemy.Unit.UnitType] += 1;
+                }
+                else
+                {
+                    typeCounts[(UnitTypes)enemy.Unit.UnitType] = 1;
+                }
+            }
+
+            foreach (var type in typeCounts.Keys)
+            {
+                if (!CurrentTotalUnits.ContainsKey(type) || CurrentTotalUnits[type] < typeCounts[type])
+                {
+                    UpdateEnemyCount(type, typeCounts[type],frame);
+                } 
+            }
+        }
+    }
+}
+

--- a/Sharky/Managers/UnitManager.cs
+++ b/Sharky/Managers/UnitManager.cs
@@ -12,6 +12,7 @@
         UnitDataService UnitDataService;
         BaseData BaseData;
         EnemyData EnemyData;
+        EnemyUnitMemoryService EnemyUnitMemoryService;
 
         float NearbyDistance = 18;
         float AvoidRange = 1;
@@ -20,7 +21,7 @@
 
         int TargetPriorityCalculationFrame;
 
-        public UnitManager(ActiveUnitData activeUnitData, SharkyUnitData sharkyUnitData, BaseData baseData, EnemyData enemyData, SharkyOptions sharkyOptions, TargetPriorityService targetPriorityService, CollisionCalculator collisionCalculator, MapDataService mapDataService, DebugService debugService, DamageService damageService, UnitDataService unitDataService)
+        public UnitManager(ActiveUnitData activeUnitData, SharkyUnitData sharkyUnitData, BaseData baseData, EnemyData enemyData, SharkyOptions sharkyOptions, TargetPriorityService targetPriorityService, CollisionCalculator collisionCalculator, MapDataService mapDataService, DebugService debugService, DamageService damageService, UnitDataService unitDataService,EnemyUnitMemoryService enemyUnitMemorService)
         {
             ActiveUnitData = activeUnitData;
 
@@ -34,6 +35,8 @@
             DamageService = damageService;
             UnitDataService = unitDataService;
             EnemyData = enemyData;
+
+            EnemyUnitMemoryService = enemyUnitMemorService;
 
 
             TargetPriorityCalculationFrame = 0;
@@ -57,6 +60,8 @@
 
         public override IEnumerable<SC2APIProtocol.Action> OnFrame(ResponseObservation observation)
         {
+            EnemyUnitMemoryService.ProcessActiveUnitData(ActiveUnitData.EnemyUnits,observation.Observation.GameLoop);
+
             ProcessObservation(observation);
             return null;
         }
@@ -139,6 +144,12 @@
                 {
                     if (!removedEnemy.Unit.IsHallucination)
                     {
+                        UnitTypes type = (UnitTypes) removedEnemy.Unit.UnitType;
+                        if (EnemyUnitMemoryService.CurrentTotalUnits.ContainsKey(type))
+                        {
+                            EnemyUnitMemoryService.UpdateEnemyCount(type, EnemyUnitMemoryService.CurrentTotalUnits[type], observation.Observation.GameLoop);
+                        }
+
                         ActiveUnitData.EnemyDeaths++;
                         ActiveUnitData.EnemySupplyLost += (int)removedEnemy.UnitTypeData.FoodRequired;
                         ActiveUnitData.EnemyResourcesLost += (int)removedEnemy.UnitTypeData.MineralCost + (int)removedEnemy.UnitTypeData.VespeneCost;

--- a/Sharky/Pathing/MapDataService.cs
+++ b/Sharky/Pathing/MapDataService.cs
@@ -186,6 +186,7 @@
             {
                 return false;
             }
+
             return MapData.Map[(int)point.X,(int)point.Y].InSelfVision;
         }
 


### PR DESCRIPTION
A service integrated into SharkyBot to store memory about the units the enemy has in the current game. 